### PR TITLE
Bump Cluster resource state version

### DIFF
--- a/hack/gen-tf-code/main.go
+++ b/hack/gen-tf-code/main.go
@@ -377,7 +377,7 @@ func main() {
 			doc(dataClusterStatusHeader, ""),
 		),
 		generate(resources.Cluster{},
-			version(4),
+			version(5),
 			required("Name"),
 			exclude("Revision"),
 			doc(dataClusterHeader, ""),

--- a/pkg/schemas/resources/DataSource_Cluster.generated.go
+++ b/pkg/schemas/resources/DataSource_Cluster.generated.go
@@ -71,7 +71,7 @@ func DataSourceCluster() *schema.Resource {
 			"secrets":                           ComputedStruct(DataSourceClusterSecrets()),
 		},
 	}
-	res.SchemaVersion = 4
+	res.SchemaVersion = 5
 	res.StateUpgraders = []schema.StateUpgrader{
 		{
 			Type: res.CoreConfigSchema().ImpliedType(),
@@ -105,6 +105,14 @@ func DataSourceCluster() *schema.Resource {
 				return ret, nil
 			},
 			Version: 3,
+		}, {
+			Type: res.CoreConfigSchema().ImpliedType(),
+			Upgrade: func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+				ret := FlattenDataSourceCluster(ExpandDataSourceCluster(rawState))
+				ret["id"] = rawState["id"]
+				return ret, nil
+			},
+			Version: 4,
 		},
 	}
 	return res


### PR DESCRIPTION
When upgrading to this provider from `eddycharly/kops` version `1.26.0-alpha.1` the state schema changes for the Cluster resource.

This reconciles things to enable the upgrade.