### PR TITLE
Bump Cluster resource state version

### DIFF
--- a/hack/gen-tf-code/main.go
+++ b/hack/gen-tf-code/main.go
@@ -101,7 +101,7 @@ func main() {
 		"docs/resources/",
 		parser,
 		generate(resources.Cluster{},
-			version(4),
+			version(5),
 			required("Name"),
 			computedOnly("Revision"),
 			sensitive("AdminSshKey"),

--- a/pkg/schemas/resources/Resource_Cluster.generated.go
+++ b/pkg/schemas/resources/Resource_Cluster.generated.go
@@ -72,7 +72,7 @@ func ResourceCluster() *schema.Resource {
 			"revision":                          ComputedInt(),
 		},
 	}
-	res.SchemaVersion = 4
+	res.SchemaVersion = 5
 	res.StateUpgraders = []schema.StateUpgrader{
 		{
 			Type: res.CoreConfigSchema().ImpliedType(),
@@ -106,6 +106,14 @@ func ResourceCluster() *schema.Resource {
 				return ret, nil
 			},
 			Version: 3,
+		}, {
+			Type: res.CoreConfigSchema().ImpliedType(),
+			Upgrade: func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+				ret := FlattenResourceCluster(ExpandResourceCluster(rawState))
+				ret["id"] = rawState["id"]
+				return ret, nil
+			},
+			Version: 4,
 		},
 	}
 	return res


### PR DESCRIPTION
https://github.com/terraform-kops/terraform-provider-kops/pull/33 bumped the version of the data source.

We also need to bump the version of the resource itself.