### PR TITLE
Update goreleaser schema & add PR build test step.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        tf-version: [1.5.7, 1.6.6, 1.7.5]
+        tf-version: [1.6.6, 1.7.5, 1.8.5]
     runs-on: ubuntu-latest
     steps:
       - name: Install terraform
@@ -29,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.23
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -42,6 +42,37 @@ jobs:
       - name: Build install and validate against examples
         run: |
           make examples
+
+  goreleaserbuild:
+    runs-on: ubuntu-latest
+    steps:
+      # cleanup Runner to avoid "no space left on device" error
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # remove items we don't need
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: Test goreleaser build
         uses: goreleaser/goreleaser-action@v6.1.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,4 +78,4 @@ jobs:
         uses: goreleaser/goreleaser-action@v6.1.0
         with:
           version: latest
-          args: build --clean --timeout 60m -p 2
+          args: build --clean --timeout 60m -p 2 --snapshot

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,16 +25,26 @@ jobs:
           unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
           sudo mv terraform /usr/local/bin
           rm *
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.21
+
       - name: Checkout code
         uses: actions/checkout@v4
+
       - uses: actions/cache@v4
         with:
           path: /home/runner/go/pkg/mod
           key: go-mod
+
       - name: Build install and validate against examples
         run: |
           make examples
+
+      - name: Test goreleaser build
+        uses: goreleaser/goreleaser-action@v6.1.0
+        with:
+          version: latest
+          args: build --clean --timeout 60m -p 2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,21 +24,26 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: true
+
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Unshallow
         run: git fetch --prune --unshallow
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
+
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
+
       - name: Create release
         uses: goreleaser/goreleaser-action@v6.1.0
         env:
@@ -46,4 +51,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
         with:
           version: latest
-          args: release --clean --timeout 60m
+          args: release --clean --timeout 60m -p 2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
 project_name: terraform-provider-kops
 before:
   hooks:
@@ -27,7 +29,7 @@ builds:
       - -X 'github.com/terraform-kops/terraform-provider-kops/pkg/version.BuiltBy=goreleaser'
 archives:
   - id: terraform-provider-kops
-    format: zip
+    formats: [ 'zip' ]
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
     builds:
       - terraform-provider-kops

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-kops/terraform-provider-kops
 
-go 1.22.7
+go 1.23.4
 
 toolchain go1.23.0
 


### PR DESCRIPTION
Goreleaser builds are suddenly taking a long time the action runner is getting killed before completion.
This PR updates the `.goreleaser.yaml` file to match v2 schema (and cleanup goreleaser errors). 
It also drops the parallelism to 2 (from default of CPU count), so see if this helps builds succeed.