### PR TITLE
fix: update UpdateCluster method to handle new clusters

### DIFF
--- a/pkg/resources/ClusterUpdater.go
+++ b/pkg/resources/ClusterUpdater.go
@@ -31,7 +31,7 @@ func ClusterUpdater() *schema.Resource {
 
 func ClusterUpdaterCreateOrUpdate(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	in := resourcesschema.ExpandResourceClusterUpdater(d.Get("").(map[string]interface{}))
-	if err := in.UpdateCluster(config.Clientset(m)); err != nil {
+	if err := in.UpdateCluster(config.Clientset(m), d.IsNewResource()); err != nil {
 		return diag.FromErr(err)
 	}
 	d.SetId(in.ClusterName)


### PR DESCRIPTION
Add isNewResource parameter to UpdateCluster method to be able to handle nodes along with control planes during creation of new clusters. Fixes #217