### PR TITLE
feat: update GitHub Actions to use dynamic tokens

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,11 +44,18 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.GORELEASER_APP_ID }}
+          private-key: ${{ secrets.GORELEASER_APP_PRIVATE_KEY }}
+
       - name: Create release
         uses: goreleaser/goreleaser-action@v6.3.0
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:
           version: latest
           args: release --clean --timeout 60m -p 2

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -14,6 +14,12 @@ jobs:
     - uses: actions/checkout@v5
       with:
         persist-credentials: true
+    - name: Generate a token
+      id: generate-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ vars.TAGPR_APP_ID }}
+        private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
     - uses: Songmu/tagpr@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Add steps to GitHub workflows for generating tokens using  
GitHub App credentials. Update the GITHUB_TOKEN environment  
variable to utilize dynamically generated tokens instead of  
hardcoded secrets for both the release and tagpr workflows.  
This improves security and flexibility in accessing the  
GitHub API.