### PR TITLE
chore: update checkout action in tagpr workflow

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -11,15 +11,16 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-    - uses: actions/checkout@v5
-      with:
-        persist-credentials: true
     - name: Generate a token
       id: generate-token
       uses: actions/create-github-app-token@v2
       with:
         app-id: ${{ vars.TAGPR_APP_ID }}
         private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+        token: ${{ steps.generate-token.outputs.token }}
     - uses: Songmu/tagpr@v1
       env:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Replace the GitHub Actions checkout step to disable credential 
persistence and use a generated token for authentication.