### PR TITLE
fix(actions): enable credential persistence in checkout step

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -19,7 +19,7 @@ jobs:
         private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
     - uses: actions/checkout@v5
       with:
-        persist-credentials: false
+        persist-credentials: true
         token: ${{ steps.generate-token.outputs.token }}
     - uses: Songmu/tagpr@v1
       env:


### PR DESCRIPTION
Enable credential persistence in the GitHub Actions checkout step, 
allowing for better authentication management during workflow 
execution. This change improves the reliability of subsequent 
steps that require access to the repository.