### PR TITLE
ci: update Go version and improve caching in workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,11 +26,6 @@ jobs:
           sudo mv terraform /usr/local/bin
           rm *
 
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23
-
       - name: Checkout code
         uses: actions/checkout@v5
 
@@ -38,6 +33,12 @@ jobs:
         with:
           path: /home/runner/go/pkg/mod
           key: go-mod
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: Build install and validate against examples
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,11 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
 
+      - uses: actions/cache@v4
+        with:
+          path: /home/runner/go/pkg/mod
+          key: go-mod
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/verify-codegen.yaml
+++ b/.github/workflows/verify-codegen.yaml
@@ -14,16 +14,17 @@ jobs:
   verify-codegen:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.22
       - name: Checkout code
         uses: actions/checkout@v5
       - uses: actions/cache@v4
         with:
           path: /home/runner/go/pkg/mod
           key: go-mod
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
       - name: Verify codegen
         run: |
           make verify-gen

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-kops/terraform-provider-kops
 
-go 1.24.4
+go 1.25.1
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible


### PR DESCRIPTION
Updates the Go version to 1.25.1 in go.mod to leverage new features 
and enhancements. Modifies the GitHub Actions workflow to use 
'go-version-file' for setting the Go version directly from 
go.mod and enables caching to improve build performance.