### PR TITLE
fix: set region and credentials before trying to assume a role

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -94,7 +95,15 @@ func initAwsCredentials(ctx context.Context, config *config.Aws) error {
 		os.Setenv("AWS_PROFILE", config.Profile)
 	}
 	if config.AssumeRole != nil {
-		svc := sts.New(sts.Options{})
+		awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+		if err != nil {
+			return err
+		}
+
+		svc := sts.New(sts.Options{
+			Region:      config.Region,
+			Credentials: awsCfg.Credentials,
+		})
 		input := &sts.AssumeRoleInput{
 			RoleArn:         aws.String(config.AssumeRole.RoleArn),
 			RoleSessionName: aws.String("TF-PROVIDER-KOPS"),


### PR DESCRIPTION
When trying to use the `assume_role` for the `aws` directive in `kops` provider configuration like this

```terraform 

provider "kops" {
  state_store = "s3://some-state-store"

  aws {
    region = "eu-west-1"
    assume_role {
      role_arn = "arn:aws:iam::123456789012:role/Someole"
    }
  }
}

```
 I get an error when trying to run `terraform plan`.

```shell
Error: operation error STS: AssumeRole, failed to resolve service endpoint, endpoint rule error, Invalid Configuration: Missing Region
```

This Pull Request is a potential fix for this issue. It sets both the region and (in order for assume role to work) also supplies the default credentials from AWS configuration.