### PR TITLE
fix: networking spec example

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -22,37 +22,37 @@ resource "kops_cluster" "cluster" {
 
   networking {
     calico {}
-  }
 
-  topology {
-    masters = "private"
-    nodes   = "private"
-
-    dns {
-      type = "Private"
+    topology {
+      masters = "private"
+      nodes   = "private"
+  
+      dns {
+        type = "Private"
+      }
     }
-  }
 
-  # cluster subnets
-  subnet {
-    name        = "private-0"
-    provider_id = "subnet-0"
-    type        = "Private"
-    zone        = "zone-0"
-  }
-
-  subnet {
-    name        = "private-1"
-    provider_id = "subnet-1"
-    type        = "Private"
-    zone        = "zone-1"
-  }
-
-  subnet {
-    name        = "private-2"
-    provider_id = "subnet-2"
-    type        = "Private"
-    zone        = "zone-2"
+    # cluster subnets
+    subnet {
+      name        = "private-0"
+      provider_id = "subnet-0"
+      type        = "Private"
+      zone        = "zone-0"
+    }
+  
+    subnet {
+      name        = "private-1"
+      provider_id = "subnet-1"
+      type        = "Private"
+      zone        = "zone-1"
+    }
+  
+    subnet {
+      name        = "private-2"
+      provider_id = "subnet-2"
+      type        = "Private"
+      zone        = "zone-2"
+    }
   }
 
   # etcd clusters


### PR DESCRIPTION
topology and subnet are part of the networking_spec