### PR TITLE
ci: group k8s and aws-sdk dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      k8s:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      aws-sdk:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Groups `k8s.io/*` and `sigs.k8s.io/*` dependencies into a single Dependabot PR
- Groups `github.com/aws/aws-sdk-go-v2*` dependencies into a single Dependabot PR
- Reduces PR noise from individual dependency bump PRs