### PR TITLE
feat: add excludeInstanceGroups option to cluster updater

### DIFF
--- a/hack/gen-tf-code/docs/resource-cluster-updater-header.md
+++ b/hack/gen-tf-code/docs/resource-cluster-updater-header.md
@@ -48,6 +48,17 @@ resource "kops_instance_group" "master-2" {
   depends_on   = [kops_cluster.cluster]
 }
 
+resource "kops_instance_group" "runner" {
+  cluster_name = kops_cluster.cluster.name
+  name         = "runner"
+  role         = "Node"
+  min_size     = 0
+  max_size     = 3
+  machine_type = "t3.large"
+  subnets      = ["private-0"]
+  depends_on   = [kops_cluster.cluster]
+}
+
 resource "kops_cluster_updater" "updater" {
   cluster_name        = kops_cluster.cluster.name
 
@@ -56,14 +67,16 @@ resource "kops_cluster_updater" "updater" {
     master-0 = kops_instance_group.master-0.revision
     master-1 = kops_instance_group.master-1.revision
     master-2 = kops_instance_group.master-2.revision
+    runner   = kops_instance_group.runner.revision
     // ...
   }
 
   rolling_update {
-    skip                = false
-    fail_on_drain_error = true
-    fail_on_validate    = true
-    validate_count      = 1
+    skip                    = false
+    fail_on_drain_error     = true
+    fail_on_validate        = true
+    validate_count          = 1
+    exclude_instance_groups = [kops_instance_group.runner.name]
 
     // ...
   }
@@ -79,7 +92,8 @@ resource "kops_cluster_updater" "updater" {
     kops_cluster.cluster,
     kops_instance_group.master-0,
     kops_instance_group.master-1,
-    kops_instance_group.master-2
+    kops_instance_group.master-2,
+    kops_instance_group.runner
   ]
 }
 ```

--- a/pkg/api/resources/ClusterUpdater.go
+++ b/pkg/api/resources/ClusterUpdater.go
@@ -40,7 +40,7 @@ func (u *ClusterUpdater) UpdateCluster(clientset simple.Clientset, isNewResource
 		}
 	}
 	if !u.RollingUpdate.Skip {
-		if err := utils.ClusterRollingUpdate(clientset, u.ClusterName, u.RollingUpdate.RollingUpdateOptions, true); err != nil {
+		if err := utils.ClusterRollingUpdate(clientset, u.ClusterName, u.RollingUpdate.RollingUpdateOptions, true, u.RollingUpdate.ExcludeInstanceGroups); err != nil {
 			return err
 		}
 	}
@@ -64,7 +64,7 @@ func (u *ClusterUpdater) UpdateCluster(clientset simple.Clientset, isNewResource
 		}
 	}
 	if !u.RollingUpdate.Skip {
-		if err := utils.ClusterRollingUpdate(clientset, u.ClusterName, u.RollingUpdate.RollingUpdateOptions, false); err != nil {
+		if err := utils.ClusterRollingUpdate(clientset, u.ClusterName, u.RollingUpdate.RollingUpdateOptions, false, u.RollingUpdate.ExcludeInstanceGroups); err != nil {
 			return err
 		}
 	}

--- a/pkg/api/resources/RollingUpdateOptions.go
+++ b/pkg/api/resources/RollingUpdateOptions.go
@@ -5,5 +5,9 @@ import "github.com/terraform-kops/terraform-provider-kops/pkg/api/utils"
 type RollingUpdateOptions struct {
 	// Skip allows skipping cluster rolling update
 	Skip bool
+	// ExcludeInstanceGroups is a list of instance group names to exclude from rolling updates.
+	// Excluded instance groups will have their cloud resources updated (ASG launch template)
+	// but existing instances will not be terminated or replaced.
+	ExcludeInstanceGroups []string
 	utils.RollingUpdateOptions
 }

--- a/pkg/api/utils/cluster_rolling_update_test.go
+++ b/pkg/api/utils/cluster_rolling_update_test.go
@@ -1,0 +1,116 @@
+package utils
+
+import (
+	"testing"
+
+	"k8s.io/kops/pkg/apis/kops"
+)
+
+func makeIGWithName(name string, role kops.InstanceGroupRole) kops.InstanceGroup {
+	ig := kops.InstanceGroup{
+		Spec: kops.InstanceGroupSpec{
+			Role: role,
+		},
+	}
+	ig.Name = name
+	return ig
+}
+
+func TestFilterInstanceGroups(t *testing.T) {
+	items := []kops.InstanceGroup{
+		makeIGWithName("master-0", kops.InstanceGroupRoleControlPlane),
+		makeIGWithName("master-1", kops.InstanceGroupRoleControlPlane),
+		makeIGWithName("nodes", kops.InstanceGroupRoleNode),
+		makeIGWithName("runner", kops.InstanceGroupRoleNode),
+		makeIGWithName("api-server", kops.InstanceGroupRoleAPIServer),
+	}
+
+	tests := []struct {
+		name             string
+		controlPlaneOnly bool
+		excludeNames     []string
+		wantNames        []string
+	}{
+		{
+			name:             "no exclusions, all instance groups",
+			controlPlaneOnly: false,
+			excludeNames:     nil,
+			wantNames:        []string{"master-0", "master-1", "nodes", "runner", "api-server"},
+		},
+		{
+			name:             "no exclusions, control plane only",
+			controlPlaneOnly: true,
+			excludeNames:     nil,
+			wantNames:        []string{"master-0", "master-1", "api-server"},
+		},
+		{
+			name:             "exclude a node instance group",
+			controlPlaneOnly: false,
+			excludeNames:     []string{"runner"},
+			wantNames:        []string{"master-0", "master-1", "nodes", "api-server"},
+		},
+		{
+			name:             "exclude a control plane instance group",
+			controlPlaneOnly: false,
+			excludeNames:     []string{"master-0"},
+			wantNames:        []string{"master-1", "nodes", "runner", "api-server"},
+		},
+		{
+			name:             "exclude control plane IG from control plane only phase",
+			controlPlaneOnly: true,
+			excludeNames:     []string{"master-0"},
+			wantNames:        []string{"master-1", "api-server"},
+		},
+		{
+			name:             "exclude non-existent name has no effect",
+			controlPlaneOnly: false,
+			excludeNames:     []string{"does-not-exist"},
+			wantNames:        []string{"master-0", "master-1", "nodes", "runner", "api-server"},
+		},
+		{
+			name:             "empty exclude list same as nil",
+			controlPlaneOnly: false,
+			excludeNames:     []string{},
+			wantNames:        []string{"master-0", "master-1", "nodes", "runner", "api-server"},
+		},
+		{
+			name:             "exclude multiple instance groups",
+			controlPlaneOnly: false,
+			excludeNames:     []string{"runner", "nodes"},
+			wantNames:        []string{"master-0", "master-1", "api-server"},
+		},
+		{
+			name:             "exclude node IG from control plane only phase has no effect",
+			controlPlaneOnly: true,
+			excludeNames:     []string{"runner"},
+			wantNames:        []string{"master-0", "master-1", "api-server"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterInstanceGroups(items, tt.controlPlaneOnly, tt.excludeNames)
+
+			if len(got) != len(tt.wantNames) {
+				t.Fatalf("got %d instance groups, want %d", len(got), len(tt.wantNames))
+			}
+			for i, ig := range got {
+				if ig.Name != tt.wantNames[i] {
+					t.Errorf("instance group %d: got name %q, want %q", i, ig.Name, tt.wantNames[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFilterInstanceGroupsEmptyInput(t *testing.T) {
+	got := filterInstanceGroups(nil, false, nil)
+	if got != nil {
+		t.Errorf("expected nil for empty input, got %v", got)
+	}
+
+	got = filterInstanceGroups([]kops.InstanceGroup{}, false, []string{"runner"})
+	if got != nil {
+		t.Errorf("expected nil for empty items, got %v", got)
+	}
+}

--- a/pkg/schemas/resources/Resource_RollingUpdateOptions.generated.go
+++ b/pkg/schemas/resources/Resource_RollingUpdateOptions.generated.go
@@ -13,17 +13,18 @@ var _ = Schema
 func ResourceRollingUpdateOptions() *schema.Resource {
 	res := &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"skip":                OptionalBool(),
-			"master_interval":     OptionalDuration(),
-			"node_interval":       OptionalDuration(),
-			"bastion_interval":    OptionalDuration(),
-			"fail_on_drain_error": OptionalBool(),
-			"fail_on_validate":    OptionalBool(),
-			"post_drain_delay":    OptionalDuration(),
-			"validation_timeout":  OptionalDuration(),
-			"validate_count":      OptionalInt(),
-			"cloud_only":          OptionalBool(),
-			"force":               OptionalBool(),
+			"skip":                    OptionalBool(),
+			"exclude_instance_groups": OptionalList(String()),
+			"master_interval":         OptionalDuration(),
+			"node_interval":           OptionalDuration(),
+			"bastion_interval":        OptionalDuration(),
+			"fail_on_drain_error":     OptionalBool(),
+			"fail_on_validate":        OptionalBool(),
+			"post_drain_delay":        OptionalDuration(),
+			"validation_timeout":      OptionalDuration(),
+			"validate_count":          OptionalInt(),
+			"cloud_only":              OptionalBool(),
+			"force":                   OptionalBool(),
 		},
 	}
 
@@ -38,6 +39,18 @@ func ExpandResourceRollingUpdateOptions(in map[string]interface{}) resources.Rol
 		Skip: func(in interface{}) bool {
 			return bool(ExpandBool(in))
 		}(in["skip"]),
+		ExcludeInstanceGroups: func(in interface{}) []string {
+			return func(in interface{}) []string {
+				if in == nil {
+					return nil
+				}
+				var out []string
+				for _, in := range in.([]interface{}) {
+					out = append(out, string(ExpandString(in)))
+				}
+				return out
+			}(in)
+		}(in["exclude_instance_groups"]),
 		RollingUpdateOptions: func(in interface{}) utils.RollingUpdateOptions {
 			return utilsschemas.ExpandResourceRollingUpdateOptions(in.(map[string]interface{}))
 		}(in),
@@ -48,6 +61,15 @@ func FlattenResourceRollingUpdateOptionsInto(in resources.RollingUpdateOptions, 
 	out["skip"] = func(in bool) interface{} {
 		return FlattenBool(bool(in))
 	}(in.Skip)
+	out["exclude_instance_groups"] = func(in []string) interface{} {
+		return func(in []string) []interface{} {
+			var out []interface{}
+			for _, in := range in {
+				out = append(out, FlattenString(string(in)))
+			}
+			return out
+		}(in)
+	}(in.ExcludeInstanceGroups)
 	utilsschemas.FlattenResourceRollingUpdateOptionsInto(in.RollingUpdateOptions, out)
 }
 

--- a/pkg/schemas/resources/Resource_RollingUpdateOptions.generated_test.go
+++ b/pkg/schemas/resources/Resource_RollingUpdateOptions.generated_test.go
@@ -21,17 +21,18 @@ func TestExpandResourceRollingUpdateOptions(t *testing.T) {
 			name: "default",
 			args: args{
 				in: map[string]interface{}{
-					"skip":                false,
-					"master_interval":     nil,
-					"node_interval":       nil,
-					"bastion_interval":    nil,
-					"fail_on_drain_error": false,
-					"fail_on_validate":    false,
-					"post_drain_delay":    nil,
-					"validation_timeout":  nil,
-					"validate_count":      nil,
-					"cloud_only":          false,
-					"force":               false,
+					"skip":                    false,
+					"exclude_instance_groups": func() []interface{} { return nil }(),
+					"master_interval":         nil,
+					"node_interval":           nil,
+					"bastion_interval":        nil,
+					"fail_on_drain_error":     false,
+					"fail_on_validate":        false,
+					"post_drain_delay":        nil,
+					"validation_timeout":      nil,
+					"validate_count":          nil,
+					"cloud_only":              false,
+					"force":                   false,
 				},
 			},
 			want: _default,
@@ -49,17 +50,18 @@ func TestExpandResourceRollingUpdateOptions(t *testing.T) {
 
 func TestFlattenResourceRollingUpdateOptionsInto(t *testing.T) {
 	_default := map[string]interface{}{
-		"skip":                false,
-		"master_interval":     nil,
-		"node_interval":       nil,
-		"bastion_interval":    nil,
-		"fail_on_drain_error": false,
-		"fail_on_validate":    false,
-		"post_drain_delay":    nil,
-		"validation_timeout":  nil,
-		"validate_count":      nil,
-		"cloud_only":          false,
-		"force":               false,
+		"skip":                    false,
+		"exclude_instance_groups": func() []interface{} { return nil }(),
+		"master_interval":         nil,
+		"node_interval":           nil,
+		"bastion_interval":        nil,
+		"fail_on_drain_error":     false,
+		"fail_on_validate":        false,
+		"post_drain_delay":        nil,
+		"validation_timeout":      nil,
+		"validate_count":          nil,
+		"cloud_only":              false,
+		"force":                   false,
 	}
 	type args struct {
 		in resources.RollingUpdateOptions
@@ -82,6 +84,17 @@ func TestFlattenResourceRollingUpdateOptionsInto(t *testing.T) {
 				in: func() resources.RollingUpdateOptions {
 					subject := resources.RollingUpdateOptions{}
 					subject.Skip = false
+					return subject
+				}(),
+			},
+			want: _default,
+		},
+		{
+			name: "ExcludeInstanceGroups - default",
+			args: args{
+				in: func() resources.RollingUpdateOptions {
+					subject := resources.RollingUpdateOptions{}
+					subject.ExcludeInstanceGroups = nil
 					return subject
 				}(),
 			},
@@ -211,17 +224,18 @@ func TestFlattenResourceRollingUpdateOptionsInto(t *testing.T) {
 
 func TestFlattenResourceRollingUpdateOptions(t *testing.T) {
 	_default := map[string]interface{}{
-		"skip":                false,
-		"master_interval":     nil,
-		"node_interval":       nil,
-		"bastion_interval":    nil,
-		"fail_on_drain_error": false,
-		"fail_on_validate":    false,
-		"post_drain_delay":    nil,
-		"validation_timeout":  nil,
-		"validate_count":      nil,
-		"cloud_only":          false,
-		"force":               false,
+		"skip":                    false,
+		"exclude_instance_groups": func() []interface{} { return nil }(),
+		"master_interval":         nil,
+		"node_interval":           nil,
+		"bastion_interval":        nil,
+		"fail_on_drain_error":     false,
+		"fail_on_validate":        false,
+		"post_drain_delay":        nil,
+		"validation_timeout":      nil,
+		"validate_count":          nil,
+		"cloud_only":              false,
+		"force":                   false,
 	}
 	type args struct {
 		in resources.RollingUpdateOptions
@@ -244,6 +258,17 @@ func TestFlattenResourceRollingUpdateOptions(t *testing.T) {
 				in: func() resources.RollingUpdateOptions {
 					subject := resources.RollingUpdateOptions{}
 					subject.Skip = false
+					return subject
+				}(),
+			},
+			want: _default,
+		},
+		{
+			name: "ExcludeInstanceGroups - default",
+			args: args{
+				in: func() resources.RollingUpdateOptions {
+					subject := resources.RollingUpdateOptions{}
+					subject.ExcludeInstanceGroups = nil
 					return subject
 				}(),
 			},


### PR DESCRIPTION
Updates the ClusterUpdater functionality to include  an `exclude_instance_groups` option for rolling updates,  allowing users to specify instance groups that should  not be terminated or replaced. 

Adds a new instance group  called "runner" and updates corresponding documentation  to reflect these changes. 
Additional tests verify the  functionality of instance group filtering.