### PR TITLE
feat: support customizing node drain timeout

### DIFF
--- a/docs/resources/cluster_updater.md
+++ b/docs/resources/cluster_updater.md
@@ -141,6 +141,7 @@ The following arguments are supported:
 - `validate_count` - (Optional) - Int - ValidateCount is the amount of time that a cluster needs to be validated after single node update.
 - `cloud_only` - (Optional) - Bool - CloudOnly perform rolling update without confirming progress with k8s.
 - `force` - (Optional) - Bool - Force forces a rolling update.
+- `drain_timeout` - (Optional) - Duration - DrainTimeout is the maximum amount of time to wait while draining a node.
 
 ### validate_options
 

--- a/pkg/api/utils/cluster_rolling_update.go
+++ b/pkg/api/utils/cluster_rolling_update.go
@@ -36,6 +36,8 @@ type RollingUpdateOptions struct {
 	CloudOnly bool
 	// Force forces a rolling update
 	Force bool
+	// DrainTimeout is the maximum amount of time to wait while draining a node
+	DrainTimeout *metav1.Duration
 }
 
 func ClusterInstanceGroupsNeedingUpdate(clientset simple.Clientset, clusterName string) ([]string, error) {
@@ -167,6 +169,7 @@ func ClusterRollingUpdate(clientset simple.Clientset, clusterName string, option
 	PostDrainDelay := 5 * time.Second
 	ValidationTimeout := 15 * time.Minute
 	ValidateCount := 2
+	DrainTimeout := 15 * time.Minute
 	if options.MasterInterval != nil {
 		MasterInterval = options.MasterInterval.Duration
 	}
@@ -185,6 +188,9 @@ func ClusterRollingUpdate(clientset simple.Clientset, clusterName string, option
 	if options.ValidateCount != nil {
 		ValidateCount = *options.ValidateCount
 	}
+	if options.DrainTimeout != nil {
+		DrainTimeout = options.DrainTimeout.Duration
+	}
 	d := &instancegroups.RollingUpdateCluster{
 		Cluster:                 kc,
 		Clientset:               clientset,
@@ -202,6 +208,7 @@ func ClusterRollingUpdate(clientset simple.Clientset, clusterName string, option
 		PostDrainDelay:          PostDrainDelay,
 		ValidationTimeout:       ValidationTimeout,
 		ValidateCount:           ValidateCount,
+		DrainTimeout:            DrainTimeout,
 		ValidateTickDuration:    30 * time.Second,
 		ValidateSuccessDuration: 10 * time.Second,
 	}

--- a/pkg/schemas/resources/Resource_RollingUpdateOptions.generated.go
+++ b/pkg/schemas/resources/Resource_RollingUpdateOptions.generated.go
@@ -25,6 +25,7 @@ func ResourceRollingUpdateOptions() *schema.Resource {
 			"validate_count":          OptionalInt(),
 			"cloud_only":              OptionalBool(),
 			"force":                   OptionalBool(),
+			"drain_timeout":           OptionalDuration(),
 		},
 	}
 

--- a/pkg/schemas/resources/Resource_RollingUpdateOptions.generated_test.go
+++ b/pkg/schemas/resources/Resource_RollingUpdateOptions.generated_test.go
@@ -33,6 +33,7 @@ func TestExpandResourceRollingUpdateOptions(t *testing.T) {
 					"validate_count":          nil,
 					"cloud_only":              false,
 					"force":                   false,
+					"drain_timeout":           nil,
 				},
 			},
 			want: _default,
@@ -62,6 +63,7 @@ func TestFlattenResourceRollingUpdateOptionsInto(t *testing.T) {
 		"validate_count":          nil,
 		"cloud_only":              false,
 		"force":                   false,
+		"drain_timeout":           nil,
 	}
 	type args struct {
 		in resources.RollingUpdateOptions
@@ -205,6 +207,17 @@ func TestFlattenResourceRollingUpdateOptionsInto(t *testing.T) {
 				in: func() resources.RollingUpdateOptions {
 					subject := resources.RollingUpdateOptions{}
 					subject.Force = false
+					return subject
+				}(),
+			},
+			want: _default,
+		},
+		{
+			name: "DrainTimeout - default",
+			args: args{
+				in: func() resources.RollingUpdateOptions {
+					subject := resources.RollingUpdateOptions{}
+					subject.DrainTimeout = nil
 					return subject
 				}(),
 			},
@@ -236,6 +249,7 @@ func TestFlattenResourceRollingUpdateOptions(t *testing.T) {
 		"validate_count":          nil,
 		"cloud_only":              false,
 		"force":                   false,
+		"drain_timeout":           nil,
 	}
 	type args struct {
 		in resources.RollingUpdateOptions
@@ -379,6 +393,17 @@ func TestFlattenResourceRollingUpdateOptions(t *testing.T) {
 				in: func() resources.RollingUpdateOptions {
 					subject := resources.RollingUpdateOptions{}
 					subject.Force = false
+					return subject
+				}(),
+			},
+			want: _default,
+		},
+		{
+			name: "DrainTimeout - default",
+			args: args{
+				in: func() resources.RollingUpdateOptions {
+					subject := resources.RollingUpdateOptions{}
+					subject.DrainTimeout = nil
 					return subject
 				}(),
 			},

--- a/pkg/schemas/utils/Resource_RollingUpdateOptions.generated.go
+++ b/pkg/schemas/utils/Resource_RollingUpdateOptions.generated.go
@@ -141,6 +141,25 @@ func ExpandResourceRollingUpdateOptions(in map[string]interface{}) utils.Rolling
 		Force: func(in interface{}) bool {
 			return bool(ExpandBool(in))
 		}(in["force"]),
+		DrainTimeout: func(in interface{}) *meta.Duration {
+			if in == nil {
+				return nil
+			}
+			if reflect.DeepEqual(in, reflect.Zero(reflect.TypeOf(in)).Interface()) {
+				return nil
+			}
+			return func(in interface{}) *meta.Duration {
+				if in == nil {
+					return nil
+				}
+				if _, ok := in.([]interface{}); ok && len(in.([]interface{})) == 0 {
+					return nil
+				}
+				return func(in meta.Duration) *meta.Duration {
+					return &in
+				}(ExpandDuration(in))
+			}(in)
+		}(in["drain_timeout"]),
 	}
 }
 
@@ -217,6 +236,16 @@ func FlattenResourceRollingUpdateOptionsInto(in utils.RollingUpdateOptions, out 
 	out["force"] = func(in bool) interface{} {
 		return FlattenBool(bool(in))
 	}(in.Force)
+	out["drain_timeout"] = func(in *meta.Duration) interface{} {
+		return func(in *meta.Duration) interface{} {
+			if in == nil {
+				return nil
+			}
+			return func(in meta.Duration) interface{} {
+				return FlattenDuration(in)
+			}(*in)
+		}(in)
+	}(in.DrainTimeout)
 }
 
 func FlattenResourceRollingUpdateOptions(in utils.RollingUpdateOptions) map[string]interface{} {

--- a/pkg/schemas/utils/Resource_RollingUpdateOptions.generated_test.go
+++ b/pkg/schemas/utils/Resource_RollingUpdateOptions.generated_test.go
@@ -31,6 +31,7 @@ func TestExpandResourceRollingUpdateOptions(t *testing.T) {
 					"validate_count":      nil,
 					"cloud_only":          false,
 					"force":               false,
+					"drain_timeout":       nil,
 				},
 			},
 			want: _default,
@@ -58,6 +59,7 @@ func TestFlattenResourceRollingUpdateOptionsInto(t *testing.T) {
 		"validate_count":      nil,
 		"cloud_only":          false,
 		"force":               false,
+		"drain_timeout":       nil,
 	}
 	type args struct {
 		in utils.RollingUpdateOptions
@@ -179,6 +181,17 @@ func TestFlattenResourceRollingUpdateOptionsInto(t *testing.T) {
 				in: func() utils.RollingUpdateOptions {
 					subject := utils.RollingUpdateOptions{}
 					subject.Force = false
+					return subject
+				}(),
+			},
+			want: _default,
+		},
+		{
+			name: "DrainTimeout - default",
+			args: args{
+				in: func() utils.RollingUpdateOptions {
+					subject := utils.RollingUpdateOptions{}
+					subject.DrainTimeout = nil
 					return subject
 				}(),
 			},
@@ -208,6 +221,7 @@ func TestFlattenResourceRollingUpdateOptions(t *testing.T) {
 		"validate_count":      nil,
 		"cloud_only":          false,
 		"force":               false,
+		"drain_timeout":       nil,
 	}
 	type args struct {
 		in utils.RollingUpdateOptions
@@ -329,6 +343,17 @@ func TestFlattenResourceRollingUpdateOptions(t *testing.T) {
 				in: func() utils.RollingUpdateOptions {
 					subject := utils.RollingUpdateOptions{}
 					subject.Force = false
+					return subject
+				}(),
+			},
+			want: _default,
+		},
+		{
+			name: "DrainTimeout - default",
+			args: args{
+				in: func() utils.RollingUpdateOptions {
+					subject := utils.RollingUpdateOptions{}
+					subject.DrainTimeout = nil
 					return subject
 				}(),
 			},


### PR DESCRIPTION
Support customizing the node drain timeout.

Optimally, this would be backported to 1.34 as well since it is still within kops's support window.