### PR TITLE
feat: backport admin credential lifetime to v1.35

### DIFF
--- a/docs/resources/cluster_updater.md
+++ b/docs/resources/cluster_updater.md
@@ -110,6 +110,7 @@ The following arguments are supported:
 - `apply` - (Optional) - [apply_options](#apply_options) - Apply holds cluster apply options.
 - `rolling_update` - (Optional) - [rolling_update_options](#rolling_update_options) - RollingUpdate holds cluster rolling update options.
 - `validate` - (Optional) - [validate_options](#validate_options) - Validate holds cluster validation options.
+- `admin_lifetime` - (Optional) - Duration - AdminLifetime is the lifetime of the admin credentials minted to talk to the kubernetes API. Raise it above the kops default of 18h when a rolling update is expected to run longer than the credentials would otherwise remain valid.
 
 ## Nested resources
 

--- a/pkg/api/resources/ClusterUpdater.go
+++ b/pkg/api/resources/ClusterUpdater.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"github.com/terraform-kops/terraform-provider-kops/pkg/api/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kops/pkg/client/simple"
 )
 
@@ -21,6 +22,8 @@ type ClusterUpdater struct {
 	RollingUpdate RollingUpdateOptions
 	// Validate holds cluster validation options
 	Validate ValidateOptions
+	// AdminLifetime is the lifetime of the admin credentials minted to talk to the kubernetes API. Raise it above the kops default of 18h when a rolling update is expected to run longer than the credentials would otherwise remain valid.
+	AdminLifetime *metav1.Duration
 }
 
 func (u *ClusterUpdater) UpdateCluster(clientset simple.Clientset, isNewResource bool) error {
@@ -35,12 +38,12 @@ func (u *ClusterUpdater) UpdateCluster(clientset simple.Clientset, isNewResource
 		}
 	}
 	if !u.Validate.Skip {
-		if err := utils.ClusterValidate(clientset, u.ClusterName, u.Validate.ValidateOptions); err != nil {
+		if err := utils.ClusterValidate(clientset, u.ClusterName, u.Validate.ValidateOptions, u.AdminLifetime); err != nil {
 			return err
 		}
 	}
 	if !u.RollingUpdate.Skip {
-		if err := utils.ClusterRollingUpdate(clientset, u.ClusterName, u.RollingUpdate.RollingUpdateOptions, true, u.RollingUpdate.ExcludeInstanceGroups); err != nil {
+		if err := utils.ClusterRollingUpdate(clientset, u.ClusterName, u.RollingUpdate.RollingUpdateOptions, true, u.RollingUpdate.ExcludeInstanceGroups, u.AdminLifetime); err != nil {
 			return err
 		}
 	}
@@ -59,12 +62,12 @@ func (u *ClusterUpdater) UpdateCluster(clientset simple.Clientset, isNewResource
 		}
 	}
 	if !u.Validate.Skip {
-		if err := utils.ClusterValidate(clientset, u.ClusterName, u.Validate.ValidateOptions); err != nil {
+		if err := utils.ClusterValidate(clientset, u.ClusterName, u.Validate.ValidateOptions, u.AdminLifetime); err != nil {
 			return err
 		}
 	}
 	if !u.RollingUpdate.Skip {
-		if err := utils.ClusterRollingUpdate(clientset, u.ClusterName, u.RollingUpdate.RollingUpdateOptions, false, u.RollingUpdate.ExcludeInstanceGroups); err != nil {
+		if err := utils.ClusterRollingUpdate(clientset, u.ClusterName, u.RollingUpdate.RollingUpdateOptions, false, u.RollingUpdate.ExcludeInstanceGroups, u.AdminLifetime); err != nil {
 			return err
 		}
 	}

--- a/pkg/api/utils/cluster_rolling_update.go
+++ b/pkg/api/utils/cluster_rolling_update.go
@@ -124,14 +124,14 @@ func filterInstanceGroups(items []kops.InstanceGroup, controlPlaneOnly bool, exc
 	return result
 }
 
-func ClusterRollingUpdate(clientset simple.Clientset, clusterName string, options RollingUpdateOptions, controlPlaneOnly bool, excludeInstanceGroups []string) error {
+func ClusterRollingUpdate(clientset simple.Clientset, clusterName string, options RollingUpdateOptions, controlPlaneOnly bool, excludeInstanceGroups []string, adminLifetime *metav1.Duration) error {
 	kc, err := clientset.GetCluster(context.Background(), clusterName)
 	if err != nil {
 		return err
 	}
 	var k8sClient kubernetes.Interface
 	var nodes []v1.Node
-	configBuilder, err := GetKubeConfigBuilder(clientset, clusterName, nil, false)
+	configBuilder, err := GetKubeConfigBuilder(clientset, clusterName, adminDuration(adminLifetime), false)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/utils/cluster_validate.go
+++ b/pkg/api/utils/cluster_validate.go
@@ -22,7 +22,7 @@ type ValidateOptions struct {
 	PollInterval *metav1.Duration
 }
 
-func makeValidator(clientset simple.Clientset, clusterName string) (validation.ClusterValidator, error) {
+func makeValidator(clientset simple.Clientset, clusterName string, adminLifetime *metav1.Duration) (validation.ClusterValidator, error) {
 	kc, err := clientset.GetCluster(context.Background(), clusterName)
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func makeValidator(clientset simple.Clientset, clusterName string) (validation.C
 	if len(list.Items) == 0 {
 		return nil, fmt.Errorf("no InstanceGroup objects found")
 	}
-	configBuilder, err := GetKubeConfigBuilder(clientset, clusterName, nil, false)
+	configBuilder, err := GetKubeConfigBuilder(clientset, clusterName, adminDuration(adminLifetime), false)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func makeValidator(clientset simple.Clientset, clusterName string) (validation.C
 }
 
 func ClusterIsValid(clientset simple.Clientset, clusterName string) (bool, error) {
-	if validator, err := makeValidator(clientset, clusterName); err != nil {
+	if validator, err := makeValidator(clientset, clusterName, nil); err != nil {
 		return false, err
 	} else {
 		result, err := validator.Validate(context.Background())
@@ -78,8 +78,8 @@ func ClusterIsValid(clientset simple.Clientset, clusterName string) (bool, error
 	}
 }
 
-func ClusterValidate(clientset simple.Clientset, clusterName string, options ValidateOptions) error {
-	if validator, err := makeValidator(clientset, clusterName); err != nil {
+func ClusterValidate(clientset simple.Clientset, clusterName string, options ValidateOptions, adminLifetime *metav1.Duration) error {
+	if validator, err := makeValidator(clientset, clusterName, adminLifetime); err != nil {
 		return err
 	} else {
 		timeout := time.Now()

--- a/pkg/api/utils/kube.go
+++ b/pkg/api/utils/kube.go
@@ -4,11 +4,22 @@ import (
 	"context"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/kops/pkg/client/simple"
 	"k8s.io/kops/pkg/kubeconfig"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 )
+
+// adminDuration converts an optional admin credential lifetime into the form
+// expected by GetKubeConfigBuilder. A nil value keeps kops'
+// DefaultKubecfgAdminLifetime.
+func adminDuration(in *metav1.Duration) *time.Duration {
+	if in == nil {
+		return nil
+	}
+	return &in.Duration
+}
 
 func GetKubeConfigBuilder(clientset simple.Clientset, clusterName string, admin *time.Duration, internal bool) (*kubeconfig.KubeconfigBuilder, error) {
 	cluster, err := clientset.GetCluster(context.Background(), clusterName)

--- a/pkg/schemas/resources/Resource_ClusterUpdater.generated.go
+++ b/pkg/schemas/resources/Resource_ClusterUpdater.generated.go
@@ -1,9 +1,12 @@
 package schemas
 
 import (
+	"reflect"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-kops/terraform-provider-kops/pkg/api/resources"
 	. "github.com/terraform-kops/terraform-provider-kops/pkg/schemas"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Schema
@@ -18,6 +21,7 @@ func ResourceClusterUpdater() *schema.Resource {
 			"apply":            OptionalStruct(ResourceApplyOptions()),
 			"rolling_update":   OptionalStruct(ResourceRollingUpdateOptions()),
 			"validate":         OptionalStruct(ResourceValidateOptions()),
+			"admin_lifetime":   OptionalDuration(),
 		},
 	}
 
@@ -79,6 +83,25 @@ func ExpandResourceClusterUpdater(in map[string]interface{}) resources.ClusterUp
 				return resources.ValidateOptions{}
 			}(in)
 		}(in["validate"]),
+		AdminLifetime: func(in interface{}) *meta.Duration {
+			if in == nil {
+				return nil
+			}
+			if reflect.DeepEqual(in, reflect.Zero(reflect.TypeOf(in)).Interface()) {
+				return nil
+			}
+			return func(in interface{}) *meta.Duration {
+				if in == nil {
+					return nil
+				}
+				if _, ok := in.([]interface{}); ok && len(in.([]interface{})) == 0 {
+					return nil
+				}
+				return func(in meta.Duration) *meta.Duration {
+					return &in
+				}(ExpandDuration(in))
+			}(in)
+		}(in["admin_lifetime"]),
 	}
 }
 
@@ -119,6 +142,16 @@ func FlattenResourceClusterUpdaterInto(in resources.ClusterUpdater, out map[stri
 			return []interface{}{FlattenResourceValidateOptions(in)}
 		}(in)
 	}(in.Validate)
+	out["admin_lifetime"] = func(in *meta.Duration) interface{} {
+		return func(in *meta.Duration) interface{} {
+			if in == nil {
+				return nil
+			}
+			return func(in meta.Duration) interface{} {
+				return FlattenDuration(in)
+			}(*in)
+		}(in)
+	}(in.AdminLifetime)
 }
 
 func FlattenResourceClusterUpdater(in resources.ClusterUpdater) map[string]interface{} {

--- a/pkg/schemas/resources/Resource_ClusterUpdater.generated_test.go
+++ b/pkg/schemas/resources/Resource_ClusterUpdater.generated_test.go
@@ -32,6 +32,7 @@ func TestExpandResourceClusterUpdater(t *testing.T) {
 					"validate": func() []interface{} {
 						return []interface{}{FlattenResourceValidateOptions(resources.ValidateOptions{})}
 					}(),
+					"admin_lifetime": nil,
 				},
 			},
 			want: _default,
@@ -60,6 +61,7 @@ func TestFlattenResourceClusterUpdaterInto(t *testing.T) {
 		"validate": func() []interface{} {
 			return []interface{}{FlattenResourceValidateOptions(resources.ValidateOptions{})}
 		}(),
+		"admin_lifetime": nil,
 	}
 	type args struct {
 		in resources.ClusterUpdater
@@ -148,6 +150,17 @@ func TestFlattenResourceClusterUpdaterInto(t *testing.T) {
 				in: func() resources.ClusterUpdater {
 					subject := resources.ClusterUpdater{}
 					subject.Validate = resources.ValidateOptions{}
+					return subject
+				}(),
+			},
+			want: _default,
+		},
+		{
+			name: "AdminLifetime - default",
+			args: args{
+				in: func() resources.ClusterUpdater {
+					subject := resources.ClusterUpdater{}
+					subject.AdminLifetime = nil
 					return subject
 				}(),
 			},
@@ -178,6 +191,7 @@ func TestFlattenResourceClusterUpdater(t *testing.T) {
 		"validate": func() []interface{} {
 			return []interface{}{FlattenResourceValidateOptions(resources.ValidateOptions{})}
 		}(),
+		"admin_lifetime": nil,
 	}
 	type args struct {
 		in resources.ClusterUpdater
@@ -266,6 +280,17 @@ func TestFlattenResourceClusterUpdater(t *testing.T) {
 				in: func() resources.ClusterUpdater {
 					subject := resources.ClusterUpdater{}
 					subject.Validate = resources.ValidateOptions{}
+					return subject
+				}(),
+			},
+			want: _default,
+		},
+		{
+			name: "AdminLifetime - default",
+			args: args{
+				in: func() resources.ClusterUpdater {
+					subject := resources.ClusterUpdater{}
+					subject.AdminLifetime = nil
 					return subject
 				}(),
 			},


### PR DESCRIPTION
Backports #491 to the `v1.35` release line.

`v1.35` is a new maintenance branch created from the `v1.35.2` tag. #469 is already present on this line (it merged shortly before `v1.35.2` was cut), so only #491 is backported here.

### Cherry-picks

- `8a35deb` — feat: support customizing kube API admin credential lifetime (#491)

### Verification

Applied with no conflicts. On this branch:

- `go build ./...` — OK
- `go vet ./...` — OK
- `go test ./pkg/...` — OK
- `make clean gen` — zero diff, so the cherry-picked generated schemas are byte-identical to what the generator emits against kops v1.35.1

The upstream APIs both changes rely on are present in kops v1.35.1 (`instancegroups.RollingUpdateCluster.DrainTimeout`), and `GetKubeConfigBuilder` has the same signature here as on `main`, so no shims were needed.

### Releasing

tagpr will not manage this branch — `tagpr.releaseBranch` is a single exact-match string and its tag lookup runs a repo-wide `git tag`, so it would pick up `v1.36.1` and propose re-releasing an existing tag. Cut the release by tagging `v1.35.3` by hand; `release.yaml` triggers on `tags: "*"` with no branch constraint. Remember to bump `.version` and `CHANGELOG.md` in a follow-up before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtHCgp75irjUUCYJU9PyfR
